### PR TITLE
Modify get command to retrieve all key-value pairs from a single secret

### DIFF
--- a/SHARED_TASK_NOTES.md
+++ b/SHARED_TASK_NOTES.md
@@ -1,16 +1,39 @@
-# Goldfinch - Project Status
+# Goldfinch - Shared Task Notes
 
-## PROJECT COMPLETE ✅
+## Latest Changes (2025-12-12)
 
-All work is complete. The application has been fully modified according to the primary goal.
+Modified the `get` command to operate on top-level secrets instead of individual keys.
 
-### Summary
+### Current Command Behavior:
+- `list` command: Lists all top-level secret names in the AWS account
+- `get <SECRET_NAME>` command: Returns ALL k/v pairs from a specific secret (changed from getting a specific key)
+- `search <PATTERN>` command: Searches both secret names AND keys within secrets
 
-- `list` command: Lists only top-level secret names
-- `search` command: Searches both secret names AND keys within secrets
-- `get` command: Retrieves specific key values from any secret
-- All 42 tests passing
-- Documentation fully updated
-- CLI help text accurate
+### Changes Made:
+- Updated `Commands::Get` enum to accept `secret_name` instead of `key`
+- Renamed `get_key()` to `get_secret()` and modified to return all k/v pairs
+- Updated main function's Get handler to fetch single secret and display all contents
+- Modified unit tests to reflect new behavior
+- All tests passing: 31 unit tests + 9 CLI tests = 40 total
 
-No further work needed on this project.
+### Example Usage:
+```bash
+# Plain format - displays key-value pairs line by line
+goldfinch get my-secret --format plain
+# Output:
+# api_key: secret123
+# port: 8080
+# enabled: true
+
+# JSON format (default) - displays complete JSON object
+goldfinch get my-secret
+# Output: {"api_key":"secret123","port":8080,"enabled":true}
+```
+
+## Next Steps to Consider
+1. Update README.md to reflect the new `get` command behavior
+2. Review integration tests (tests/cli_tests.rs) to ensure they align with new behavior
+3. Consider updating project overview memory
+
+## Status
+Core implementation complete. Documentation updates recommended.


### PR DESCRIPTION

Key changes:
- Renamed Commands::Get field from 'key' to 'secret_name'
- Renamed get_key() function to get_secret()
- Modified get_secret() to return all k/v pairs instead of a single key value
- Updated main() Get handler to fetch single secret instead of merging all secrets
- Simplified unit tests to reflect new behavior (removed tests for key-not-found scenarios)
- Updated SHARED_TASK_NOTES.md with current command behavior and examples

All 40 tests passing (31 unit + 9 integration).