### PR TITLE
fix(auth): re-enable aws-config sso feature dropped by VULN-002 hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,8 @@ checksum = "1b180a3c8b55960db3426d8964b8745e652466a1a49fe1a2eda828046d30b5e4"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
  "aws-smithy-http",
@@ -122,11 +124,14 @@ dependencies = [
  "aws-types",
  "bytes",
  "fastrand",
+ "hex",
  "http 1.5.0",
+ "sha1",
  "time",
  "tokio",
  "tracing",
  "url",
+ "zeroize",
 ]
 
 [[package]]
@@ -194,6 +199,58 @@ name = "aws-sdk-secretsmanager"
 version = "1.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f840fd8a79900661ca05e9af1f4e2b3c74386e9fc1b4a9dd58745faf689f0"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.5.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.105.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ffd0fbe7873cb548a7aa60f9573c268fff94155397fd4f14dc9f1ecaaab8516"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.5.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.107.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175763eb222a46377df7aa257a3bca980ab3e96703fefc8f4d0b8da6ad2e254c"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -496,6 +553,15 @@ checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
@@ -639,11 +705,30 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -678,13 +763,23 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.12.1",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
@@ -848,6 +943,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,7 +1033,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1588,14 +1693,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1889,6 +2005,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vsimd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-aws-config = { version = "1.1", default-features = false, features = ["behavior-version-latest", "rt-tokio", "default-https-client"] }
+aws-config = { version = "1.1", default-features = false, features = ["behavior-version-latest", "rt-tokio", "default-https-client", "sso"] }
 aws-sdk-secretsmanager = { version = "1.13", default-features = false, features = ["default-https-client", "rt-tokio"] }
 clap = { version = "4.5", features = ["derive"] }
 tokio = { version = "1.35", default-features = false, features = ["rt-multi-thread", "macros"] }

--- a/tests/security_dependency_features.rs
+++ b/tests/security_dependency_features.rs
@@ -38,10 +38,8 @@ fn aws_config_does_not_link_credentials_process_provider() {
         !line.contains("credentials-process"),
         "aws-config must not re-enable credentials-process; got: {line}"
     );
-    assert!(
-        !line.contains("\"sso\""),
-        "aws-config must not re-enable sso; got: {line}"
-    );
+    // `sso` is deliberately re-enabled: AWS SSO profiles are a supported auth
+    // path for goldfinch and the SSO provider carries no shell-exec primitive.
 }
 
 /// VULN-008 (CWE-1164): `tokio = ["full"]` links process, signal, fs and net
@@ -94,13 +92,41 @@ fn advisory_bearing_tls_stack_is_not_resolved() {
     );
 }
 
+/// Checks the *resolved* feature set of aws-config, not just the manifest line.
+/// `credentials-process` adds no crate of its own, so Cargo.lock cannot act as
+/// a proxy for it; `cargo metadata` reports the features Cargo actually turned
+/// on after unifying every dependent's requests.
 #[test]
-fn sso_crates_are_not_resolved() {
-    // aws-sdk-sso is reachable only via aws-config's default feature set.
-    // Its presence in the lock proves the default set is active.
-    assert!(
-        !cargo_lock().contains("name = \"aws-sdk-sso\""),
-        "aws-sdk-sso is resolved, which means aws-config's default feature set \
-         (including credentials-process) is still linked"
-    );
+fn credentials_process_feature_is_not_resolved() {
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".into());
+    let out = std::process::Command::new(cargo)
+        .args(["metadata", "--format-version", "1", "--offline"])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .expect("cargo metadata must run");
+    assert!(out.status.success(), "cargo metadata failed");
+
+    let meta: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("cargo metadata must emit JSON");
+    let nodes = meta["resolve"]["nodes"]
+        .as_array()
+        .expect("resolve.nodes must be an array");
+
+    let aws_config_nodes: Vec<&serde_json::Value> = nodes
+        .iter()
+        .filter(|n| n["id"].as_str().is_some_and(|id| id.contains("aws-config")))
+        .collect();
+    assert!(!aws_config_nodes.is_empty(), "aws-config must be resolved");
+
+    for node in aws_config_nodes {
+        let features: Vec<&str> = node["features"]
+            .as_array()
+            .map(|f| f.iter().filter_map(|v| v.as_str()).collect())
+            .unwrap_or_default();
+        assert!(
+            !features.contains(&"credentials-process"),
+            "aws-config resolved with credentials-process enabled \
+             (the `sh -c` credential provider); features: {features:?}"
+        );
+    }
 }


### PR DESCRIPTION
## Problem

`goldfinch list` fails for any AWS SSO-backed profile:

```
ProfileFile provider could not be built: This behavior requires following cargo feature(s) enabled: sso.
```

#92 (VULN-002) set `default-features = false` on `aws-config` to drop the `credentials-process` provider. aws-config's default set also includes `sso`, which was removed as collateral. The PR even cited `aws-sdk-sso` vanishing from `Cargo.lock` as evidence of the fix — it was actually a regression.

## Fix

- `Cargo.toml`: add `"sso"` to aws-config's feature list. `credentials-process` stays excluded, so VULN-002 remains remediated.
- `tests/security_dependency_features.rs`: the #92 test forbade `"sso"` on the manifest line and used `aws-sdk-sso`-in-lockfile as a proxy for "defaults are on". Both overreached the finding. Removed the sso assertion and replaced the lockfile proxy with a `cargo metadata` check on aws-config's **resolved** feature set — `credentials-process` adds no crate of its own, so the lockfile could never detect it directly.
- `Cargo.lock`: `aws-sdk-sso` / `aws-sdk-ssooidc` re-resolved.

## Verification

- `cargo tree -e features -i aws-config`: `sso` present, `credentials-process` 0 occurrences
- 56 tests pass, `cargo fmt --check` clean
- New test proven RED: temporarily adding `credentials-process` to the manifest makes it fail
- Live: `goldfinch list` against an SSO profile returns secrets again
- Clippy errors are the pre-existing `json!(3.14)` PI lint noted in #92, untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
